### PR TITLE
Fixed inconsistent renaming of *args and **kwargs.

### DIFF
--- a/minipy.py
+++ b/minipy.py
@@ -894,6 +894,11 @@ class Rename(NodeTransformer):
             node.names[i] = self.rename(n)
         return self.generic_visit(node)        
 
+    def visit_arguments(self, node):
+        node.vararg = self.rename(node.vararg)
+        node.kwarg = self.rename(node.kwarg)
+        return self.generic_visit(node)
+
     def visit_Name(self, node):
         node.id = self.rename(node.id)
         return self.generic_visit(node)


### PR DESCRIPTION
minipy was renaming _args and *_kwargs only at Call nodes, when it
should be renaming them (just like any other non-keyword argument)
at FunctionDef nodes too. This behavior make simple programs crash.

This:

``` python
def x(arg, *args, **kwargs):
    print arg
    print args
    print kwargs
```

was being minified to this:

``` python
def x(a,*args,**kwargs):print a;print b;print c
```
